### PR TITLE
Support custom link name and generate line number from github permalink 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Set like as `{cap:false,re:true}`. Please do __NOT__ insert any spaces.
 | :--- | :--- | :--- |
 | cap| `true`: show caption<br> `false`: no caption | `true` |
 | re| `true`: the first line number restart from 1<br> `false`: the first line number start from original code number | `false` |
+| link| link name of url | `link` |
 
 ### Config setting
 
@@ -48,6 +49,7 @@ You can change default settings in `_config.yml` as below.
 github_code:
   cap: false
   re: true
+  link: 'link'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ $ npm install hexo-tag-github-code --save
 - URL links to raw file as below
   - https://raw.githubusercontent.com/nkmk/hexo-tag-github-code/master/index.js
   - https://gist.githubusercontent.com/nkmk/d60cdbcffdb60d624ac01871543f79a2/raw/e7528c00addcdd0b4d00cb9bbd8d225cc132fbfc/sample.py
+- URL of github permalink
+  - https://github.com/nkmk/hexo-tag-github-code/blob/master/index.js#L5-L16
+  - https://github.com/nkmk/hexo-tag-github-code/blob/master/index.js#L116
 
 ### Other site
 If URL links to raw file, it will work.

--- a/index.js
+++ b/index.js
@@ -52,9 +52,21 @@ function ghcode(args){
     var url = args[0]
     var options = {}
     var start, stop
+
+    var groups = url.match(/#(L(\d+))(-L(\d+))?/)
+    if(groups && groups.length != -1){
+        if(groups.length = 5){
+            start = parseInt(groups[2], 10)
+            stop = parseInt(groups[4], 10)
+        }else if(groups.length = 3){
+            start = parseInt(groups[2], 10)
+            stop = parseInt(groups[2], 10)
+        }
+    }
+
     if(typeof(args[1]) == 'string' && args[1].charAt(0) == '{'){
         options = str2obj(args[1])
-    }else{
+    }else if(start == undefined){
         start = args[1]
         stop = args[2]
     }
@@ -100,7 +112,7 @@ function ghcode(args){
                 })
             })
         }else if(url.search(/github.com/) != -1){
-            raw_url = url.replace(/github.com/, 'raw.githubusercontent.com').replace(/blob\//, '')
+            raw_url = url.replace(/github.com/, 'raw.githubusercontent.com').replace(/blob\//, '').replace(/#(L(\d+))(-L(\d+))?/, '')
             get_code(raw_url, function(data){
                 resolve(get_result(data, url, raw_url, start, stop, options, codeTag))
             })

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function get_result(data, url, raw_url, start, stop, options, codeTag){
     var basename = path.basename(raw_url)
     var arg
     if(options['cap']){
-        arg = [basename, 'lang:' + ext, url]
+        arg = [basename, 'lang:' + ext, url, options['link']]
     }else{
         arg = ['lang:' + ext]
     }
@@ -91,7 +91,8 @@ function ghcode(args){
 
     options = assign({
         cap: cap_default,
-        re: re_default
+        re: re_default,
+        link: 'link'
     }, options);
 
     var raw_url


### PR DESCRIPTION
Two feature

1. custom link name in options.

2. [Copy permalink](https://blog.github.com/2017-08-15-introducing-embedded-code-snippets/) contains start and end line numbers, so just parsed as `start`, `stop` options.